### PR TITLE
:bug: errors do not block next calls

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -35,7 +35,7 @@ const getResolve = ({
   return (...args) => {
     let calls = -1; // next function is recursive, it give the resolve args to each middleware
 
-    const next = async () => {
+    const next = () => {
       calls += 1; // at the end we call the real resolver
 
       if (calls === field[metaKey].middlewares.length) {

--- a/index.spec.js
+++ b/index.spec.js
@@ -640,7 +640,7 @@ describe('graphql-directives-middlewares', () => {
     const impl = jest.fn()
     const middleware = jest.fn((params, next) => (...args) => {
       impl(...args)
-      next()
+      return next()
     })
 
     // directive definition & implementation

--- a/src/index.js
+++ b/src/index.js
@@ -14,30 +14,33 @@ const getResolve = ({ directiveName, params, field, middleware }) => {
     }
   }
 
-  let calls = -1
   field[metaKey].middlewares.push({
     name: directiveName,
     impl: middleware,
     params,
   })
 
-  // next function is recursive, it give the resolve args to each middleware
-  const next = (...args) => async () => {
-    calls += 1
-    // at the end we call the real resolver
-    if (calls === field[metaKey].middlewares.length) {
-      return field[metaKey].baseResolver(...args)
+  return (...args) => {
+    let calls = -1
+
+    // next function is recursive, it give the resolve args to each middleware
+    const next = async () => {
+      calls += 1
+      // at the end we call the real resolver
+      if (calls === field[metaKey].middlewares.length) {
+        return field[metaKey].baseResolver(...args)
+      }
+
+      // take the next middleware and try to call it
+      const nextMiddleware = field[metaKey].middlewares[calls]
+      if (!nextMiddleware) {
+        throw new Error('No more middleware but no base resolver found!')
+      }
+      return nextMiddleware.impl(nextMiddleware.params, next)(...args)
     }
 
-    // take the next middleware and try to call it
-    const nextMiddleware = field[metaKey].middlewares[calls]
-    if (!nextMiddleware) {
-      throw new Error('No more middleware but no base resolver found!')
-    }
-    return nextMiddleware.impl(nextMiddleware.params, next(...args))(...args)
+    return next()
   }
-
-  return (...args) => next(...args)()
 }
 
 export const createVisitFieldDefinition = (directiveName, middleware) =>

--- a/src/index.js
+++ b/src/index.js
@@ -24,7 +24,7 @@ const getResolve = ({ directiveName, params, field, middleware }) => {
     let calls = -1
 
     // next function is recursive, it give the resolve args to each middleware
-    const next = async () => {
+    const next = () => {
       calls += 1
       // at the end we call the real resolver
       if (calls === field[metaKey].middlewares.length) {


### PR DESCRIPTION
When throw an error in directive, the `calls`  counter is not set to start.

- [x] fix error
- [x] write test